### PR TITLE
Replace dev mode with explicit configuration settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "jinja2",
     "pyyaml",
     "GitPython",
+    "natsort",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/deploy_tools/deploy.py
+++ b/src/deploy_tools/deploy.py
@@ -51,9 +51,9 @@ def _remove_releases(to_remove: list[Release], layout: Layout) -> None:
     for release in to_remove:
         name = release.module.name
         version = release.module.version
+        deprecated = release.deprecated
 
-        from_deprecated = not release.module.is_dev_mode()
-        _remove_deployed_module(name, version, layout, from_deprecated)
+        _remove_deployed_module(name, version, layout, from_deprecated=deprecated)
 
 
 def _deploy_new_releases(to_add: list[Release], layout: Layout) -> None:
@@ -146,7 +146,7 @@ def _remove_name_folders(
         _delete_modulefiles_name_folder(layout, release.module.name, True)
 
     for release in removed:
-        _delete_modulefiles_name_folder(layout, release.module.name, True)
+        _delete_modulefiles_name_folder(layout, release.module.name, release.deprecated)
         _delete_name_folder(release.module.name, layout.modules_root)
 
 

--- a/src/deploy_tools/models/deployment.py
+++ b/src/deploy_tools/models/deployment.py
@@ -1,9 +1,14 @@
-from .module import Release
+from collections import defaultdict
+
+from .module import Module, Release
 from .parent import ParentModel
 
 type ReleasesByVersion = dict[str, Release]
 type ReleasesByNameAndVersion = dict[str, ReleasesByVersion]
 type DefaultVersionsByName = dict[str, str]
+
+type ModulesByName = dict[str, list[Module]]
+type ModuleVersionsByName = dict[str, list[str]]
 
 
 class DeploymentSettings(ParentModel):
@@ -20,3 +25,33 @@ class Deployment(ParentModel):
 
     settings: DeploymentSettings
     releases: ReleasesByNameAndVersion
+
+    def get_final_deployed_modules(self) -> ModulesByName:
+        """Return modules that are expected to be deployed after a sync command.
+
+        This explicitly excludes any deprecated modules.
+        """
+        final_modules: ModulesByName = defaultdict(list)
+        for name, release_versions in self.releases.items():
+            modules = [
+                release.module
+                for release in release_versions.values()
+                if not release.deprecated
+            ]
+
+            if modules:
+                final_modules[name] = modules
+
+        return final_modules
+
+    def get_final_deployed_versions(self) -> ModuleVersionsByName:
+        """Return module versions that are expected to be deployed after a sync command.
+
+        This explicitly excludes any deprecated modules.
+        """
+        final_versions: ModuleVersionsByName = defaultdict(list)
+
+        for name, modules in self.get_final_deployed_modules().items():
+            final_versions[name] = [module.version for module in modules]
+
+        return final_versions

--- a/src/deploy_tools/models/module.py
+++ b/src/deploy_tools/models/module.py
@@ -13,8 +13,6 @@ Application = Annotated[
     ApptainerApp | ShellApp | BinaryApp, Field(..., discriminator="app_type")
 ]
 
-DEVELOPMENT_VERSION = "dev"
-
 
 class ModuleDependency(ParentModel):
     """Specify an Environment Module to include as a dependency.
@@ -47,9 +45,7 @@ class Module(ParentModel):
     dependencies: Sequence[ModuleDependency] = []
     env_vars: Sequence[EnvVar] = []
     applications: list[Application]
-
-    def is_dev_mode(self) -> bool:
-        return self.version == DEVELOPMENT_VERSION
+    allow_updates: bool = False
 
 
 class Release(ParentModel):

--- a/src/deploy_tools/models/module.py
+++ b/src/deploy_tools/models/module.py
@@ -46,6 +46,7 @@ class Module(ParentModel):
     env_vars: Sequence[EnvVar] = []
     applications: list[Application]
     allow_updates: bool = False
+    exclude_from_defaults: bool = False
 
 
 class Release(ParentModel):

--- a/src/deploy_tools/models/schemas/deployment.json
+++ b/src/deploy_tools/models/schemas/deployment.json
@@ -286,6 +286,11 @@
           "default": false,
           "title": "Allow Updates",
           "type": "boolean"
+        },
+        "exclude_from_defaults": {
+          "default": false,
+          "title": "Exclude From Defaults",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/models/schemas/deployment.json
+++ b/src/deploy_tools/models/schemas/deployment.json
@@ -281,6 +281,11 @@
           },
           "title": "Applications",
           "type": "array"
+        },
+        "allow_updates": {
+          "default": false,
+          "title": "Allow Updates",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/models/schemas/module.json
+++ b/src/deploy_tools/models/schemas/module.json
@@ -268,6 +268,11 @@
           "default": false,
           "title": "Allow Updates",
           "type": "boolean"
+        },
+        "exclude_from_defaults": {
+          "default": false,
+          "title": "Exclude From Defaults",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/models/schemas/module.json
+++ b/src/deploy_tools/models/schemas/module.json
@@ -263,6 +263,11 @@
           },
           "title": "Applications",
           "type": "array"
+        },
+        "allow_updates": {
+          "default": false,
+          "title": "Allow Updates",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/models/schemas/release.json
+++ b/src/deploy_tools/models/schemas/release.json
@@ -268,6 +268,11 @@
           "default": false,
           "title": "Allow Updates",
           "type": "boolean"
+        },
+        "exclude_from_defaults": {
+          "default": false,
+          "title": "Exclude From Defaults",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/models/schemas/release.json
+++ b/src/deploy_tools/models/schemas/release.json
@@ -263,6 +263,11 @@
           },
           "title": "Applications",
           "type": "array"
+        },
+        "allow_updates": {
+          "default": false,
+          "title": "Allow Updates",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/deploy_tools/modulefile.py
+++ b/src/deploy_tools/modulefile.py
@@ -2,10 +2,8 @@ import re
 from collections import defaultdict
 
 from .layout import Layout
-from .models.deployment import DefaultVersionsByName
+from .models.deployment import DefaultVersionsByName, ModuleVersionsByName
 from .templater import Templater, TemplateType
-
-type ModuleVersionsByName = dict[str, list[str]]
 
 VERSION_GLOB = f"*/[!{Layout.DEFAULT_VERSION_FILENAME}]*"
 

--- a/src/deploy_tools/validate.py
+++ b/src/deploy_tools/validate.py
@@ -1,8 +1,9 @@
 import logging
 from collections import defaultdict
-from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+from natsort import natsorted
 
 from .build import build
 from .layout import Layout
@@ -230,8 +231,12 @@ def _get_all_default_versions(
         if name in final_defaults:
             continue
 
-        version_list = deepcopy(final_deployed_module_versions[name])
-        version_list.sort()
-        final_defaults[name] = version_list[-1]
+        # The key follows natsort's documentation for supporting non-SemVer strings
+        # E.g. 1.2rc1 should come before 1.2.1 or 1.2
+        sorted_versions = natsorted(
+            final_deployed_module_versions[name],
+            key=lambda x: x.replace(".", "~") + "z",
+        )
+        final_defaults[name] = sorted_versions[-1]
 
     return final_defaults

--- a/tests/samples/deploy-tools-output/deployment.yaml
+++ b/tests/samples/deploy-tools-output/deployment.yaml
@@ -3,6 +3,7 @@ releases:
     v2.14.10:
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: binary
           hash: d1750274a336f0a090abf196a832cee14cb9f1c2fc3d20d80b0dbfeff83550fa
@@ -18,6 +19,7 @@ releases:
     '0.1':
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: apptainer
           container:
@@ -50,6 +52,7 @@ releases:
     '0.2':
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: apptainer
           container:
@@ -83,6 +86,7 @@ releases:
     i13-1:
       deprecated: false
       module:
+        allow_updates: false
         applications: []
         dependencies:
         - name: edge-containers-cli
@@ -100,6 +104,7 @@ releases:
     p47:
       deprecated: false
       module:
+        allow_updates: false
         applications: []
         dependencies:
         - name: edge-containers-cli
@@ -118,6 +123,7 @@ releases:
     '0.1':
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: apptainer
           container:
@@ -174,6 +180,7 @@ releases:
     '0.1':
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: apptainer
           container:
@@ -221,6 +228,7 @@ releases:
     '0.2':
       deprecated: false
       module:
+        allow_updates: false
         applications: []
         dependencies:
         - name: dls-pmac-control
@@ -235,6 +243,7 @@ releases:
     '0.1':
       deprecated: false
       module:
+        allow_updates: false
         applications:
         - app_type: apptainer
           container:

--- a/tests/samples/deploy-tools-output/deployment.yaml
+++ b/tests/samples/deploy-tools-output/deployment.yaml
@@ -13,6 +13,7 @@ releases:
         dependencies: []
         description: Demonstration of binary download
         env_vars: []
+        exclude_from_defaults: false
         name: argocd
         version: v2.14.10
   dls-pmac-control:
@@ -47,6 +48,7 @@ releases:
         env_vars:
         - name: EXAMPLE_VALUE
           value: Test message EXAMPLE_VALUE from example-module-file version 0.1
+        exclude_from_defaults: false
         name: dls-pmac-control
         version: '0.1'
     '0.2':
@@ -80,6 +82,7 @@ releases:
         env_vars:
         - name: EXAMPLE_VALUE
           value: Test message EXAMPLE_VALUE from example-module-file version 0.2
+        exclude_from_defaults: false
         name: dls-pmac-control
         version: '0.2'
   ec:
@@ -99,6 +102,7 @@ releases:
           value: i13-1-beamline/i13-1
         - name: EC_SERVICES_REPO
           value: https://gitlab.diamond.ac.uk/controls/containers/beamline/i13-1-services.git
+        exclude_from_defaults: false
         name: ec
         version: i13-1
     p47:
@@ -117,6 +121,7 @@ releases:
           value: p47-beamline/p47
         - name: EC_SERVICES_REPO
           value: https://github.com/epics-containers/p47-services
+        exclude_from_defaults: false
         name: ec
         version: p47
   edge-containers-cli:
@@ -174,6 +179,7 @@ releases:
           value: ARGOCD
         - name: EC_LOG_URL
           value: https://graylog.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A{service_name}*
+        exclude_from_defaults: false
         name: edge-containers-cli
         version: '0.1'
   example-module-apps:
@@ -222,6 +228,7 @@ releases:
         env_vars:
         - name: OTHER_VALUE
           value: Test message OTHER_VALUE from example-module-folder
+        exclude_from_defaults: false
         name: example-module-apps
         version: '0.1'
   example-module-deps:
@@ -237,6 +244,7 @@ releases:
           version: '0.1'
         description: Demonstration of deploy-tools dependencies
         env_vars: []
+        exclude_from_defaults: false
         name: example-module-deps
         version: '0.2'
   phoebus:
@@ -265,6 +273,7 @@ releases:
         dependencies: []
         description: Containerised release of CSS Phoebus
         env_vars: []
+        exclude_from_defaults: false
         name: phoebus
         version: '0.1'
 settings:

--- a/tests/samples/deploy-tools-output/modules/argocd/v2.14.10/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/argocd/v2.14.10/module.yaml
@@ -8,5 +8,6 @@ applications:
 dependencies: []
 description: Demonstration of binary download
 env_vars: []
+exclude_from_defaults: false
 name: argocd
 version: v2.14.10

--- a/tests/samples/deploy-tools-output/modules/argocd/v2.14.10/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/argocd/v2.14.10/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: binary
   hash: d1750274a336f0a090abf196a832cee14cb9f1c2fc3d20d80b0dbfeff83550fa

--- a/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.1/module.yaml
@@ -26,5 +26,6 @@ description: Demonstration of the deploy-tools process
 env_vars:
 - name: EXAMPLE_VALUE
   value: Test message EXAMPLE_VALUE from example-module-file version 0.1
+exclude_from_defaults: false
 name: dls-pmac-control
 version: '0.1'

--- a/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.1/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: apptainer
   container:

--- a/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.2/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.2/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: apptainer
   container:

--- a/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.2/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/dls-pmac-control/0.2/module.yaml
@@ -26,5 +26,6 @@ description: Demonstration of the deploy-tools process
 env_vars:
 - name: EXAMPLE_VALUE
   value: Test message EXAMPLE_VALUE from example-module-file version 0.2
+exclude_from_defaults: false
 name: dls-pmac-control
 version: '0.2'

--- a/tests/samples/deploy-tools-output/modules/ec/i13-1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/ec/i13-1/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications: []
 dependencies:
 - name: edge-containers-cli

--- a/tests/samples/deploy-tools-output/modules/ec/i13-1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/ec/i13-1/module.yaml
@@ -11,5 +11,6 @@ env_vars:
   value: i13-1-beamline/i13-1
 - name: EC_SERVICES_REPO
   value: https://gitlab.diamond.ac.uk/controls/containers/beamline/i13-1-services.git
+exclude_from_defaults: false
 name: ec
 version: i13-1

--- a/tests/samples/deploy-tools-output/modules/ec/p47/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/ec/p47/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications: []
 dependencies:
 - name: edge-containers-cli

--- a/tests/samples/deploy-tools-output/modules/ec/p47/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/ec/p47/module.yaml
@@ -11,5 +11,6 @@ env_vars:
   value: p47-beamline/p47
 - name: EC_SERVICES_REPO
   value: https://github.com/epics-containers/p47-services
+exclude_from_defaults: false
 name: ec
 version: p47

--- a/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: apptainer
   container:

--- a/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/module.yaml
@@ -49,5 +49,6 @@ env_vars:
   value: ARGOCD
 - name: EC_LOG_URL
   value: https://graylog.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A{service_name}*
+exclude_from_defaults: false
 name: edge-containers-cli
 version: '0.1'

--- a/tests/samples/deploy-tools-output/modules/example-module-apps/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/example-module-apps/0.1/module.yaml
@@ -40,5 +40,6 @@ description: Demonstration of a module configuration folder
 env_vars:
 - name: OTHER_VALUE
   value: Test message OTHER_VALUE from example-module-folder
+exclude_from_defaults: false
 name: example-module-apps
 version: '0.1'

--- a/tests/samples/deploy-tools-output/modules/example-module-apps/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/example-module-apps/0.1/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: apptainer
   container:

--- a/tests/samples/deploy-tools-output/modules/example-module-deps/0.2/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/example-module-deps/0.2/module.yaml
@@ -7,5 +7,6 @@ dependencies:
   version: '0.1'
 description: Demonstration of deploy-tools dependencies
 env_vars: []
+exclude_from_defaults: false
 name: example-module-deps
 version: '0.2'

--- a/tests/samples/deploy-tools-output/modules/example-module-deps/0.2/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/example-module-deps/0.2/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications: []
 dependencies:
 - name: dls-pmac-control

--- a/tests/samples/deploy-tools-output/modules/phoebus/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/phoebus/0.1/module.yaml
@@ -1,3 +1,4 @@
+allow_updates: false
 applications:
 - app_type: apptainer
   container:

--- a/tests/samples/deploy-tools-output/modules/phoebus/0.1/module.yaml
+++ b/tests/samples/deploy-tools-output/modules/phoebus/0.1/module.yaml
@@ -20,5 +20,6 @@ applications:
 dependencies: []
 description: Containerised release of CSS Phoebus
 env_vars: []
+exclude_from_defaults: false
 name: phoebus
 version: '0.1'


### PR DESCRIPTION
This is intended to replace the 'dev mode' status to include separate, dedicated parameters :

- allow_updates: Allows you to modify all settings of a Module at any time
- exclude_from_defaults: Excludes the Module from being selected as the default. If all versions of a given Module name are excluded, Validation will fail to prevent Environment Modules creating its own, implicit default.

I have also decided to allow convenience methods on the Pydantic models, as I believe it is clearer than the alternatives.