### PR TITLE
Re-order env-vars so they are set after env-vars set in dependencies

### DIFF
--- a/src/deploy_tools/templates/modulefile
+++ b/src/deploy_tools/templates/modulefile
@@ -10,12 +10,6 @@ if { [module-info mode load] } {
     }
 }
 
-{% if env_vars|length %}
-{% for var in env_vars %}
-setenv {{ var.name }} "{{ var.value }}"
-{% endfor %}
-
-{% endif -%}
 {% if dependencies|length %}
 {% for module in dependencies %}
 {% if module.version == None %}
@@ -23,6 +17,12 @@ module load {{ module.name }}
 {% else %}
 module load {{ module.name }}/{{ module.version }}
 {% endif %}
+{% endfor %}
+
+{% endif -%}
+{% if env_vars|length %}
+{% for var in env_vars %}
+setenv {{ var.name }} "{{ var.value }}"
 {% endfor %}
 
 {% endif -%}

--- a/tests/samples/deploy-tools-output/modules/ec/i13-1/modulefile
+++ b/tests/samples/deploy-tools-output/modules/ec/i13-1/modulefile
@@ -10,10 +10,10 @@ if { [module-info mode load] } {
     }
 }
 
-setenv EC_TARGET "i13-1-beamline/i13-1"
-setenv EC_SERVICES_REPO "https://gitlab.diamond.ac.uk/controls/containers/beamline/i13-1-services.git"
-
 module load edge-containers-cli
 module load k8s-i13-1/local
+
+setenv EC_TARGET "i13-1-beamline/i13-1"
+setenv EC_SERVICES_REPO "https://gitlab.diamond.ac.uk/controls/containers/beamline/i13-1-services.git"
 
 prepend-path PATH "/tmp/deploy-tools-output/modules/ec/i13-1/entrypoints"

--- a/tests/samples/deploy-tools-output/modules/ec/p47/modulefile
+++ b/tests/samples/deploy-tools-output/modules/ec/p47/modulefile
@@ -10,10 +10,10 @@ if { [module-info mode load] } {
     }
 }
 
-setenv EC_TARGET "p47-beamline/p47"
-setenv EC_SERVICES_REPO "https://github.com/epics-containers/p47-services"
-
 module load edge-containers-cli/0.1
 module load pollux/local
+
+setenv EC_TARGET "p47-beamline/p47"
+setenv EC_SERVICES_REPO "https://github.com/epics-containers/p47-services"
 
 prepend-path PATH "/tmp/deploy-tools-output/modules/ec/p47/entrypoints"

--- a/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/modulefile
+++ b/tests/samples/deploy-tools-output/modules/edge-containers-cli/0.1/modulefile
@@ -10,9 +10,9 @@ if { [module-info mode load] } {
     }
 }
 
+module load argocd/v2.14.10
+
 setenv EC_CLI_BACKEND "ARGOCD"
 setenv EC_LOG_URL "https://graylog.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A{service_name}*"
-
-module load argocd/v2.14.10
 
 prepend-path PATH "/tmp/deploy-tools-output/modules/edge-containers-cli/0.1/entrypoints"


### PR DESCRIPTION
It seems sensible that the env-vars set by dependencies would be overwritten by the modulefile for the module you are loading.

Giles did highlight that there may be situations where your dependencies require env-vars defining before they are module loaded, such as when env-vars are needed to load the module correctly. But currently he is not doing this.